### PR TITLE
SEC-859 | Resolved Critical dependabot alerts #29 and #31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <htrace.version>4.1.5</htrace.version>
         <bigtable.version>1.24.0</bigtable.version>
         <!-- align with org.apache.spark:spark-core_2.12 -->
+        <spark.version>3.3.3</spark.version>
         <jackson2.version>2.16.0</jackson2.version>
         <lucene-solr.version>8.11.2</lucene-solr.version>
         <elasticsearch.version>8.10.4</elasticsearch.version>
@@ -509,6 +510,12 @@
     </build>
     <dependencyManagement>
         <dependencies>
+            <!-- Override TinkerPop’s transitive Spark 3.3.2 -->
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-core_2.12</artifactId>
+                <version>${spark.version}</version>
+            </dependency>
             <!-- Tinkerpop 3.x -->
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <caffeine.version>2.9.3</caffeine.version>
         <checker-qual.version>3.40.0</checker-qual.version>
         <curator.version>5.5.0</curator.version>
+        <calcite.version>1.32.0</calcite.version>
     </properties>
     <modules>
         <module>janusgraph-grpc</module>
@@ -510,6 +511,11 @@
     </build>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.calcite</groupId>
+                <artifactId>calcite-core</artifactId>
+                <version>${calcite.version}</version>
+            </dependency>
             <!-- Override TinkerPop’s transitive Spark 3.3.2 -->
             <dependency>
                 <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### Summary
1) 
 -> Upgraded spark-core_2.12 to 3.3.3
-> Added one property and one override
-> This patches [CVE-2023-39121](https://nvd.nist.gov/vuln/detail/CVE-2023-39121) and https://github.com/atlanhq/atlan-janusgraph/security/dependabot/31

2) 
-> Upgraded calcite to 1.32.0
-> Added one property and one override
-> This resolves https://github.com/atlanhq/atlan-janusgraph/security/dependabot/29


-> Verified with mvn dependency:tree and mvn verify.

-> Jira -> https://atlanhq.atlassian.net/browse/SEC-859