### PR TITLE
fix: pin netty-codec-http2 and update HBase Docker image to address C…

### DIFF
--- a/janusgraph-hbase/docker/Dockerfile
+++ b/janusgraph-hbase/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN rm -rf ./docs ./LEGAL ./*.txt ./*/*.cmd
 COPY ./hbase-site.xml /opt/hbase/conf/hbase-site.xml
 COPY ./hbase-policy.xml /opt/hbase/conf/hbase-policy.xml
 
-FROM openjdk:8-jre-buster
+FROM eclipse-temurin:8-jre
 
 ARG HBASE_UID=1000
 ARG HBASE_GID=1000

--- a/pom.xml
+++ b/pom.xml
@@ -852,6 +852,11 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
                 <version>${netty4.version}</version>
             </dependency>


### PR DESCRIPTION
…VE-2023-44487

CVE-2023-44487 (HTTP/2 Rapid Reset Attack, CVSS 7.5 High) allows a remote attacker to cause Denial of Service via HTTP/2 rapid stream resets.

Changes:
- pom.xml: Add netty-codec-http2 to managed dependency list, pinned to netty4.version (4.1.101.Final) which contains the CVE-2023-44487 fix. Without this entry, transitive pulls of netty-codec-http2 from gRPC, Solr, or HBase could resolve to a vulnerable pre-4.1.100.Final version. This fix covers: janusgraph-all, janusgraph-solr, janusgraph-dist, janusgraph-doc, and janusgraph-examples/example-hbase.

- janusgraph-hbase/docker/Dockerfile: Replace deprecated openjdk:8-jre-buster (EOL, vulnerable JVM) with eclipse-temurin:8-jre (actively maintained Eclipse Temurin build with latest security patches including CVE-2023-44487).

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
