### PR TITLE
fix: pin netty-codec-http2 in dependencyManagement to address CVE-202…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -855,6 +855,11 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
                 <version>${netty4.version}</version>
             </dependency>


### PR DESCRIPTION
…3-44487

CVE-2023-44487 (HTTP/2 Rapid Reset Attack, CWE-400, CVSS 7.5 High) allows a remote attacker to cause Denial of Service via HTTP/2 rapid stream resets.

Root cause: the root pom.xml already pins 9 Netty artifacts to ${netty4.version} (4.1.112.Final, which is patched), but netty-codec-http2 — the specific artifact implementing HTTP/2 — was absent from <dependencyManagement>. Transitive resolution from gRPC, Solr (solr-solrj), or HBase could therefore pull in a vulnerable pre-4.1.100.Final version.

Fix: add io.netty:netty-codec-http2 to <dependencyManagement> pinned to ${netty4.version} (4.1.112.Final). This single root-level change covers all 5 reported modules that inherit from this POM:
- janusgraph-all/pom.xml
- janusgraph-solr/pom.xml
- janusgraph-dist/pom.xml
- janusgraph-doc/pom.xml
- janusgraph-examples/example-hbase/pom.xml

-----

Thank you for contributing to JanusGraph!

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced in the commit message?
- [ ] Does your PR body contain #xyz where xyz is the issue number you are trying to resolve?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `master`)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you written and/or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE.txt file, including the main LICENSE.txt file in the root of this repository?
- [ ] If applicable, have you updated the NOTICE.txt file, including the main NOTICE.txt file found in the root of this repository?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
