### PR TITLE
chore: dep-cooldown — centralize threshold in atlanhq/.github

### DIFF
--- a/.github/workflows/dep-cooldown.yml
+++ b/.github/workflows/dep-cooldown.yml
@@ -1,0 +1,22 @@
+name: dep-cooldown
+
+# Calls the org-shared cooldown checker in atlanhq/.github.
+# Threshold (min-age-days) is controlled centrally by the default in the
+# reusable workflow — change it once there to apply org-wide. To override
+# per-repo, add a `with: { min-age-days: <n> }` block here.
+# Bypass: add the 'security' label to the PR (audited).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cooldown:
+    uses: atlanhq/.github/.github/workflows/reusable-dep-cooldown.yml@main
+    # Forwards SLACK_DEP_COOLDOWN_WEBHOOK to the reusable workflow so
+    # cooldown failures alert in #community-security.
+    secrets: inherit


### PR DESCRIPTION
Replaces the previous dep-cooldown PR with a cleaner version: removes the hardcoded `min-age-days: 7` so the threshold is controlled centrally by the default in `atlanhq/.github`'s reusable workflow.

## Why

Changing the cooldown threshold today would require editing every one of 263 consumer repos. After this PR merges, it's a one-line edit in `atlanhq/.github` and the new threshold takes effect on every consumer's next CI run.

## What changes

Just one line — removes `with: { min-age-days: 7 }` from the workflow file. The threshold (currently 7 days) is identical; only the source-of-truth moves.

## To override per-repo (rare)

If this specific repo needs a different threshold (e.g., customer-facing SDK wants 14 days), add `with: { min-age-days: 14 }` back to this file. The override beats the default.

## Same behaviour as before

- Triggers on every PR (opened/sync/reopened/labeled/unlabeled)
- Bypass with `security` label still works
- Slack alerts on failure still post to `#community-security`
- Backward-compatible: this is purely an architecture cleanup